### PR TITLE
fix typo: moudle -> module

### DIFF
--- a/rust-kernel/rust-for-linux.md
+++ b/rust-kernel/rust-for-linux.md
@@ -144,7 +144,7 @@ struct VDev;
 
 impl kernel::Module for VDev {
     fn init(_name: &'static CStr, _module: &'static ThisModule) -> Result<Self> {
-        // Print a banner to make sure our moudle is working
+        // Print a banner to make sure our module is working
         pr_info!("------------------------\n");
         pr_info!("starting virtual device!\n");
         pr_info!("------------------------\n");


### PR DESCRIPTION
Thank you for the nice blog! This fixes a small typo.