### PR TITLE
Tutorial code example - typo fixes

### DIFF
--- a/rust-kernel/rust-for-linux.md
+++ b/rust-kernel/rust-for-linux.md
@@ -415,9 +415,6 @@ fn write(
         offset: u64,
     ) -> Result<usize> {
         pr_info!("File for device {} was written\n", data.number);
-        let copy = reader.read_all()?;
-        let len = copy.len();
-        *data.contents.lock() = copy;
         let offset = offset.try_into()?;
         let len = reader.len();
         let new_len = len.checked_add(offset).ok_or(EINVAL)?;

--- a/rust-kernel/rust-for-linux.md
+++ b/rust-kernel/rust-for-linux.md
@@ -412,7 +412,6 @@ fn write(
         data: RefBorrow<'_, Device>,
         _file: &File,
         reader: &mut impl IoBufferReader,
-        _offset: u64,
         offset: u64,
     ) -> Result<usize> {
         pr_info!("File for device {} was written\n", data.number);


### PR DESCRIPTION
This tutorial was super helpful, thank you for making it!

Updating the tutorial code examples and removing unnecessary lines, it looks like the `-` lines were kept in diffs from the previous tutorial section.